### PR TITLE
Revert "Explicit support to generate doc and tag (#3)"

### DIFF
--- a/ubuntu/debian/rules
+++ b/ubuntu/debian/rules
@@ -15,13 +15,3 @@ override_dh_auto_install:
 	dh_auto_install --destdir=debian/tmp
 	find . -type d -name install | xargs rm -rf
 	find . -type d -empty -delete
-
-# Execute doc creation to export at least the doxygen tag file
-override_dh_auto_build:
-	dh_auto_build -- doc
-	dh_auto_build
-
-override_dh_auto_install:
-	dh_auto_install
-	install -d debian/tmp/usr/share/gz/gz-cmake4/
-	install ./obj-*/*.tag.xml debian/tmp/usr/share/gz/gz-cmake4/


### PR DESCRIPTION
This reverts commit a268f64b206d5e32cec7ef1f197101f211f2a50e.

gz-cmake is not affected by the doxygen changes and does not supply a tag doxy file.